### PR TITLE
Add table field monitor extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Autofill
+
+This repository contains a minimal browser extension that detects and logs
+form fields inside HTML tables on the current page. It can be used as a
+starting point for auto‐filling or analysis tools.
+
+## Using the extension
+1. Open Chrome or any Chromium‐based browser and navigate to
+   `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this repository directory.
+4. Visit any webpage and open the browser console. The extension will print
+a list of table fields (inputs, textareas or selects) found on that page.

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,21 @@
+(function() {
+  function logTableFields() {
+    const fields = document.querySelectorAll(
+      'table input, table textarea, table select'
+    );
+    if (fields.length === 0) {
+      console.log('No table form fields found.');
+    } else {
+      console.log('Table fields found:');
+      fields.forEach(f => {
+        console.log('  -', f);
+      });
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', logTableFields);
+  } else {
+    logTableFields();
+  }
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "manifest_version": 3,
+  "name": "Table Field Monitor",
+  "version": "0.1",
+  "description": "Prints all form fields inside tables on the current page",
+  "permissions": ["activeTab"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- create Chrome extension skeleton
- add content script to log form fields in tables
- document setup steps in README

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686493c6b9848332ab033395eef5aa5d