### PR TITLE
Add dummy data autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ also detected.
    `chrome://extensions`.
 2. Enable **Developer mode**.
 3. Click **Load unpacked** and select this repository directory.
-4. Visit any webpage and open the browser console. The extension will print
-   a list of form fields (inputs, textareas or selects) found on that page,
-   including those loaded dynamically.
+4. Visit any webpage and open the browser console. The extension will
+   automatically fill common name and email fields with example data and
+   print a list of form fields (inputs, textareas or selects) found on that
+   page, including those loaded dynamically.

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,4 +1,10 @@
 (function () {
+  const dummyData = {
+    fullName: 'Jane Smith',
+    firstName: 'Jane',
+    lastName: 'Smith',
+    email: 'jane.smith@example.com',
+  };
   /**
    * Keeps track of form fields that were already reported so we do not
    * print duplicates when new nodes are inserted into the DOM.
@@ -23,6 +29,28 @@
     );
   }
 
+  function autofillField(field) {
+    const label = getFieldLabel(field).toLowerCase();
+    const text = [label, field.name, field.id, field.placeholder]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase();
+
+    if (field.readOnly || field.disabled) {
+      return;
+    }
+
+    if (/\b(first|given)\s*name\b/.test(text)) {
+      field.value = dummyData.firstName;
+    } else if (/\b(last|family|surname)\s*name?\b/.test(text)) {
+      field.value = dummyData.lastName;
+    } else if (text.includes('email')) {
+      field.value = dummyData.email;
+    } else if (/\bname\b/.test(text)) {
+      field.value = dummyData.fullName;
+    }
+  }
+
   /**
    * Logs any new form fields currently in the document.
    */
@@ -33,6 +61,7 @@
         seen.add(field);
         const label = getFieldLabel(field);
         console.log('Field found:', label, field);
+        autofillField(field);
       }
     });
   }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Form Field Monitor",
-  "version": "0.2",
-  "description": "Logs form fields on the current page, including dynamic ones",
+  "version": "0.3",
+  "description": "Logs and auto-fills common form fields with dummy data",
   "permissions": ["activeTab"],
   "content_scripts": [
     {


### PR DESCRIPTION
## Summary
- auto-fill name and email fields using dummy data
- describe feature in README
- update extension manifest

## Testing
- `node -c contentScript.js`