### PR TITLE
Simplify label lookup

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -63,7 +63,7 @@
 
   // Derive a human-readable label for a field
   function getFieldLabel(field) {
-    const byId = field.id ? document.querySelector(`label[for=\"${field.id}\"]`) : null;
+    const byId = field.id && document.querySelector(`label[for="${field.id}"]`);
     const labelText = byId ? byId.textContent.trim() : '';
     return (
       field.getAttribute('aria-label') ||


### PR DESCRIPTION
## Summary
- simplify query selector logic when retrieving labels for form fields

## Testing
- `node --check contentScript.js`
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865e46de8808332b3495c13ab3d1843